### PR TITLE
Fix dev scripts for Gnome 49

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "scripts": {
     "dev": "bun check && ./scripts/build.sh -r",
-    "dev:nested": "bun build:install && env MUTTER_DEBUG_DUMMY_MODE_SPECS=1500x900 dbus-run-session -- gnome-shell --nested --wayland",
+    "dev:nested": "bun build:install && env MUTTER_DEBUG_DUMMY_MODE_SPECS=1500x900 ./scripts/dev-run.sh",
     "build": "./scripts/build.sh",
-    "build:install": "bun check && ./scripts/build.sh --install",
+    "build:install": "bun check && ./scripts/build.sh",
     "setup": "./scripts/setup.sh",
     "log": "./scripts/log.sh -f",
     "log:all": "./scripts/log.sh",

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+version_output=$(gnome-shell --version 2>/dev/null)
+major_version=$(echo "$version_output" | awk '{print $3}' | cut -d. -f1)
+
+if (( major_version >= 49 )); then
+    dbus-run-session -- gnome-shell --devkit --wayland
+else
+	dbus-run-session -- gnome-shell --nested --wayland
+fi


### PR DESCRIPTION
Since `--nested` was removed from Gnome 49 ([issue](https://discourse.gnome.org/t/gnome-49-nested-sessions-no-longer-possible/30987)), I added compatible command.
It will require installed mutter-devkit or similar package for different OS (mine is Arch btw)