### PR TITLE
Fix GNOME Shell crash (signal 11) caused by JS callbacks during GC sweep

### DIFF
--- a/src/core/dbus/services/windows-service.ts
+++ b/src/core/dbus/services/windows-service.ts
@@ -14,9 +14,9 @@ export class WindowsService {
     private windowOpenedSignalId: number = 0;
     private windowFocusSignalId: number = 0;
     private workspaceChangedSignalId: number = 0;
+    private windowDestroyHandlerId: number = 0;
+    private focusIdleSourceId: number = 0;
 
-    // Track individual window signal IDs
-    private windowDestroySignalIds: Map<number, number> = new Map();
     private windowSizeSignalIds: Map<number, number> = new Map();
 
     // Track previous focused window for paste-to-active-app functionality
@@ -42,10 +42,24 @@ export class WindowsService {
     private setupWindowEventListeners(): void {
         logger.debug("WindowsService: Setting up GNOME window event listeners");
 
-        // Connect to GNOME's global window events
-        const _display = global.display;
+        this.windowDestroyHandlerId = (global as any).window_manager.connect(
+            "destroy",
+            (_wm: unknown, actor: unknown) => {
+                try {
+                    const metaWindow = (actor as Meta.WindowActor)?.meta_window;
+                    if (!metaWindow) return;
+                    const windowId = metaWindow.get_id();
+                    logger.debug(
+                        `Window ${windowId} destroy signal triggered - emitting closewindow`,
+                    );
+                    this.emitCloseWindow(windowId.toString());
+                    this.windowSizeSignalIds.delete(windowId);
+                } catch (error) {
+                    logger.debug(`Error handling window destroy: ${error}`);
+                }
+            },
+        );
 
-        // Window opened event
         this.windowOpenedSignalId = global.display.connect(
             "window-created",
             (_display, window) => {
@@ -58,8 +72,6 @@ export class WindowsService {
                         windowInfo.title,
                     );
 
-                    // Connect to this window's signals
-                    this.connectToWindowDestroy(window);
                     this.connectToWindowSizeChanges(window);
                 } catch (error) {
                     logger.debug(
@@ -69,46 +81,49 @@ export class WindowsService {
             },
         );
 
-        // Connect to destroy signals for all existing windows
-        this.connectToExistingWindows();
+        this.connectSizeSignalsToExistingWindows();
 
-        // Window focus changed event
         this.windowFocusSignalId = global.display.connect(
             "notify::focus-window",
             () => {
                 try {
-                    // Add a small delay to ensure GNOME Shell has updated its internal state
-                    GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
-                        const focusWindow = global.display.focus_window;
-                        if (focusWindow) {
-                            // Track previous focused window
-                            const currentWmClass =
-                                focusWindow.get_wm_class() || "";
-                            if (
-                                !this.windowManager.isTargetWindow(
-                                    currentWmClass,
-                                )
-                            ) {
-                                // Only update previous window if current is not Vicinae
-                                this.previousFocusedWindow = {
-                                    id: focusWindow.get_id(),
-                                    wmClass: currentWmClass,
-                                };
-                            }
+                    if (this.focusIdleSourceId) {
+                        GLib.source_remove(this.focusIdleSourceId);
+                        this.focusIdleSourceId = 0;
+                    }
 
-                            this.emitFocusWindow(
-                                focusWindow.get_id().toString(),
-                            );
-                        }
-                        return GLib.SOURCE_REMOVE;
-                    });
+                    this.focusIdleSourceId = GLib.idle_add(
+                        GLib.PRIORITY_DEFAULT_IDLE,
+                        () => {
+                            this.focusIdleSourceId = 0;
+                            const focusWindow = global.display.focus_window;
+                            if (focusWindow) {
+                                const currentWmClass =
+                                    focusWindow.get_wm_class() || "";
+                                if (
+                                    !this.windowManager.isTargetWindow(
+                                        currentWmClass,
+                                    )
+                                ) {
+                                    this.previousFocusedWindow = {
+                                        id: focusWindow.get_id(),
+                                        wmClass: currentWmClass,
+                                    };
+                                }
+
+                                this.emitFocusWindow(
+                                    focusWindow.get_id().toString(),
+                                );
+                            }
+                            return GLib.SOURCE_REMOVE;
+                        },
+                    );
                 } catch (error) {
                     logger.debug(`Error handling window focus event: ${error}`);
                 }
             },
         );
 
-        // Workspace changed event
         this.workspaceChangedSignalId = global.workspace_manager?.connect(
             "notify::active-workspace",
             () => {
@@ -133,90 +148,15 @@ export class WindowsService {
         );
     }
 
-    private connectToWindowDestroy(window: Meta.Window): void {
-        const windowId = window.get_id();
-
-        try {
-            let signalId: number | undefined;
-
-            let connectedSignal = "";
-
-            // Try to connect to destroy signal first
-            try {
-                logger.debug(
-                    `Attempting to connect 'destroy' signal for window ${windowId}`,
-                );
-                signalId = window.connect("destroy", () => {
-                    try {
-                        logger.debug(
-                            `Window ${windowId} destroy signal triggered - emitting closewindow`,
-                        );
-                        this.emitCloseWindow(windowId.toString());
-                        // Clean up the signal ID
-                        this.windowDestroySignalIds.delete(windowId);
-                    } catch (error) {
-                        logger.debug(
-                            `Error emitting closewindow for ${windowId}: ${error}`,
-                        );
-                    }
-                });
-                connectedSignal = "destroy";
-                logger.debug(
-                    `Successfully connected to 'destroy' signal for window ${windowId}`,
-                );
-            } catch (_destroyError) {
-                logger.debug(
-                    `'destroy' signal not available for window ${windowId}, trying 'unmanaged'`,
-                );
-                // If destroy signal doesn't exist, try unmanaged signal
-                try {
-                    signalId = window.connect("unmanaged", () => {
-                        try {
-                            logger.debug(
-                                `Window ${windowId} unmanaged signal triggered - emitting closewindow`,
-                            );
-                            this.emitCloseWindow(windowId.toString());
-                            // Clean up the signal ID
-                            this.windowDestroySignalIds.delete(windowId);
-                        } catch (error) {
-                            logger.debug(
-                                `Error emitting closewindow for ${windowId}: ${error}`,
-                            );
-                        }
-                    });
-                    connectedSignal = "unmanaged";
-                    logger.debug(
-                        `Successfully connected to 'unmanaged' signal for window ${windowId}`,
-                    );
-                } catch (_unmanagedError) {
-                    logger.debug(
-                        `No suitable destroy signal for window ${windowId}, skipping signal connection`,
-                    );
-                    return;
-                }
-            }
-
-            // Store the signal ID for cleanup
-            if (signalId !== undefined) {
-                this.windowDestroySignalIds.set(windowId, signalId);
-                logger.debug(
-                    `Successfully connected ${connectedSignal} signal for window ${windowId} (signal ID: ${signalId})`,
-                );
-            }
-        } catch (error) {
-            logger.debug(
-                `Failed to connect any destroy signal for window ${windowId}: ${error}`,
-            );
-        }
-    }
-
     private connectToWindowSizeChanges(window: Meta.Window): void {
         const windowId = window.get_id();
 
         try {
             const signalId = window.connect("size-changed", () => {
                 try {
-                    const windowInfo = this.getWindowInfo(window);
+                    const currentWindow = this.findWindowById(windowId);
+                    if (!currentWindow) return;
+                    const windowInfo = this.getWindowInfo(currentWindow);
                     logger.debug(
                         `Window ${windowId} size changed - emitting movewindow`,
                     );
@@ -235,9 +175,6 @@ export class WindowsService {
             });
 
             this.windowSizeSignalIds.set(windowId, signalId);
-            logger.debug(
-                `Connected size-changed signal for window ${windowId}`,
-            );
         } catch (error) {
             logger.debug(
                 `Failed to connect size-changed signal for window ${windowId}: ${error}`,
@@ -245,16 +182,26 @@ export class WindowsService {
         }
     }
 
-    private connectToExistingWindows(): void {
+    private findWindowById(windowId: number): Meta.Window | null {
+        try {
+            const actors = global.get_window_actors();
+            for (const actor of actors) {
+                if (actor.meta_window?.get_id() === windowId) {
+                    return actor.meta_window;
+                }
+            }
+        } catch {
+            // ignore
+        }
+        return null;
+    }
+
+    private connectSizeSignalsToExistingWindows(): void {
         try {
             const windowActors = global.get_window_actors();
-            logger.debug(
-                `WindowsService: Connecting to ${windowActors.length} existing windows`,
-            );
 
             for (const actor of windowActors) {
                 if (actor.meta_window) {
-                    this.connectToWindowDestroy(actor.meta_window);
                     this.connectToWindowSizeChanges(actor.meta_window);
                 }
             }
@@ -314,7 +261,11 @@ export class WindowsService {
     destroy(): void {
         logger.debug("WindowsService: Cleaning up window event listeners");
 
-        // Disconnect display-level signal handlers
+        if (this.focusIdleSourceId) {
+            GLib.source_remove(this.focusIdleSourceId);
+            this.focusIdleSourceId = 0;
+        }
+
         if (this.windowOpenedSignalId) {
             global.display.disconnect(this.windowOpenedSignalId);
         }
@@ -324,44 +275,29 @@ export class WindowsService {
         if (this.workspaceChangedSignalId && global.workspace_manager) {
             global.workspace_manager.disconnect(this.workspaceChangedSignalId);
         }
+        if (this.windowDestroyHandlerId) {
+            (global as any).window_manager.disconnect(
+                this.windowDestroyHandlerId,
+            );
+        }
 
-        // Disconnect all individual window signals
-        const allWindowIds = new Set([
-            ...this.windowDestroySignalIds.keys(),
-            ...this.windowSizeSignalIds.keys(),
-        ]);
-
-        for (const windowId of allWindowIds) {
+        for (const [windowId, sizeSignalId] of this.windowSizeSignalIds) {
             try {
-                // Find the window and disconnect all its signals
                 const windowActors = global.get_window_actors();
                 const windowActor = windowActors.find(
                     (actor) => actor.meta_window?.get_id() === windowId,
                 );
 
-                if (windowActor?.meta_window) {
-                    // Disconnect destroy signal
-                    const destroySignalId =
-                        this.windowDestroySignalIds.get(windowId);
-                    if (destroySignalId) {
-                        windowActor.meta_window.disconnect(destroySignalId);
-                    }
-
-                    // Disconnect size signal
-                    const sizeSignalId = this.windowSizeSignalIds.get(windowId);
-                    if (sizeSignalId) {
-                        windowActor.meta_window.disconnect(sizeSignalId);
-                    }
+                if (windowActor?.meta_window && sizeSignalId) {
+                    windowActor.meta_window.disconnect(sizeSignalId);
                 }
             } catch (error) {
                 logger.debug(
-                    `Error disconnecting signals for window ${windowId}: ${error}`,
+                    `Error disconnecting size signal for window ${windowId}: ${error}`,
                 );
             }
         }
 
-        // Clear the maps
-        this.windowDestroySignalIds.clear();
         this.windowSizeSignalIds.clear();
 
         logger.debug("WindowsService: Window event listeners cleaned up");

--- a/src/core/launcher/window-tracker.ts
+++ b/src/core/launcher/window-tracker.ts
@@ -4,6 +4,13 @@ import { logger } from "../../utils/logger.js";
 
 declare const global: {
     display: Meta.Display;
+    window_manager: {
+        connect: (
+            signal: string,
+            callback: (...args: unknown[]) => void,
+        ) => number;
+        disconnect: (id: number) => void;
+    };
     get_window_actors: () => Meta.WindowActor[];
     get_current_time: () => number;
 };
@@ -11,8 +18,7 @@ declare const global: {
 export class WindowTracker {
     private trackedWindows = new Set<number>();
     private windowCreatedHandler?: number;
-    private windowDestroySignalIds = new Map<number, number | undefined>();
-    private windowValidators = new Map<number, () => boolean>();
+    private windowDestroyHandler?: number;
     private isDestroying = false;
 
     constructor(
@@ -33,7 +39,27 @@ export class WindowTracker {
                 },
             );
 
-            // Handle existing windows
+            this.windowDestroyHandler = global.window_manager.connect(
+                "destroy",
+                (_wm: unknown, actor: unknown) => {
+                    if (this.isDestroying) return;
+                    try {
+                        const metaWindow = (actor as Meta.WindowActor)
+                            ?.meta_window;
+                        const windowId = metaWindow?.get_id();
+                        if (windowId && this.trackedWindows.has(windowId)) {
+                            this.trackedWindows.delete(windowId);
+                            this.onWindowUntracked(windowId);
+                            logger.debug(
+                                `WindowTracker: Untracking destroyed window ${windowId}`,
+                            );
+                        }
+                    } catch {
+                        // Window already gone, safe to ignore
+                    }
+                },
+            );
+
             this.scanExistingWindows();
             logger.info("WindowTracker: Window tracking enabled");
         } catch (error) {
@@ -53,25 +79,11 @@ export class WindowTracker {
             this.windowCreatedHandler = undefined;
         }
 
-        // Safely disconnect all window destroy handlers
-        for (const [windowId, signalId] of this.windowDestroySignalIds) {
-            if (signalId) {
-                try {
-                    const window = this.getWindowById(windowId);
-                    if (window && this.isWindowValid(window)) {
-                        window.disconnect(signalId);
-                    }
-                } catch (_error) {
-                    // Window might be already destroyed, which is expected
-                    logger.debug(
-                        `WindowTracker: Signal already disconnected for window ${windowId}`,
-                    );
-                }
-            }
+        if (this.windowDestroyHandler) {
+            global.window_manager.disconnect(this.windowDestroyHandler);
+            this.windowDestroyHandler = undefined;
         }
 
-        this.windowDestroySignalIds.clear();
-        this.windowValidators.clear();
         this.trackedWindows.clear();
         this.isDestroying = false;
         logger.info("WindowTracker: Window tracking disabled");
@@ -102,12 +114,7 @@ export class WindowTracker {
     }
 
     private handleNewWindow(window: Meta.Window) {
-        if (this.isDestroying || !this.isValidWindow(window)) {
-            logger.debug(
-                "WindowTracker: Invalid window object or destroying, skipping",
-            );
-            return;
-        }
+        if (this.isDestroying) return;
 
         try {
             const wmClass = window.get_wm_class();
@@ -115,52 +122,14 @@ export class WindowTracker {
             const windowId = window.get_id();
 
             if (!wmClass || !title || windowId <= 0) {
-                logger.debug("WindowTracker: Invalid window properties", {
-                    wmClass,
-                    title,
-                    windowId,
-                });
                 return;
             }
 
             if (wmClass.toLowerCase().includes(this.appClass.toLowerCase())) {
                 if (!this.trackedWindows.has(windowId)) {
                     this.trackedWindows.add(windowId);
-
-                    // Create a validator function for this window
-                    const validator = () => this.isWindowValid(window);
-                    this.windowValidators.set(windowId, validator);
-
                     this.onWindowTracked(windowId);
-
-                    // Center the window after tracking
                     this.centerWindow(window);
-
-                    // Set up window destroy handler with safer approach
-                    // Check if the window has the destroy signal (X11 vs Wayland)
-                    let signalId: number | undefined;
-                    try {
-                        // Try to connect to destroy signal first
-                        signalId = window.connect("destroy", () => {
-                            this.handleWindowDestroyed(window);
-                        });
-                    } catch (_error) {
-                        // If destroy signal doesn't exist, try unmanaged signal
-                        try {
-                            signalId = window.connect("unmanaged", () => {
-                                this.handleWindowDestroyed(window);
-                            });
-                        } catch (_unmanagedError) {
-                            // If neither signal exists, log and continue without signal tracking
-                            logger.debug(
-                                `WindowTracker: No suitable destroy signal for window ${windowId}, skipping signal connection`,
-                            );
-                        }
-                    }
-
-                    if (signalId) {
-                        this.windowDestroySignalIds.set(windowId, signalId);
-                    }
 
                     logger.debug(
                         `WindowTracker: Tracking new window ${windowId} (${wmClass})`,
@@ -171,87 +140,10 @@ export class WindowTracker {
             logger.error("WindowTracker: Error handling new window", {
                 error: error instanceof Error ? error.message : String(error),
                 stack: error instanceof Error ? error.stack : undefined,
-                windowId: window?.get_id?.() || "unknown",
             });
         }
     }
 
-    private isValidWindow(window: Meta.Window): boolean {
-        if (!window) return false;
-
-        // Check if required methods exist
-        if (typeof window.get_wm_class !== "function") return false;
-        if (typeof window.get_id !== "function") return false;
-
-        // Check if window is in a valid state
-        try {
-            const windowId = window.get_id();
-            return windowId > 0 && windowId !== undefined;
-        } catch {
-            return false;
-        }
-    }
-
-    private isWindowValid(window: Meta.Window): boolean {
-        if (!window) return false;
-
-        try {
-            // Check if window still exists in the window list
-            const windowActors = global.get_window_actors();
-            const stillExists = windowActors.some(
-                (actor) =>
-                    actor.meta_window &&
-                    actor.meta_window.get_id() === window.get_id(),
-            );
-
-            if (!stillExists) return false;
-
-            // Try to access window properties to ensure it's still valid
-            window.get_id();
-            window.get_wm_class();
-            return true;
-        } catch {
-            return false;
-        }
-    }
-
-    private handleWindowDestroyed(window: Meta.Window) {
-        if (this.isDestroying || !this.isValidWindow(window)) return;
-
-        const windowId = window.get_id();
-        if (this.trackedWindows.has(windowId)) {
-            this.trackedWindows.delete(windowId);
-            this.windowValidators.delete(windowId);
-            this.onWindowUntracked(windowId);
-
-            // Clean up the destroy signal handler - don't try to disconnect from destroyed window
-            this.windowDestroySignalIds.delete(windowId);
-
-            logger.debug(
-                `WindowTracker: Untracking destroyed window ${windowId}`,
-            );
-        }
-    }
-
-    private getWindowById(windowId: number): Meta.Window | null {
-        try {
-            const actors = global.get_window_actors();
-            for (const actor of actors) {
-                const window = actor.meta_window;
-                if (window && window.get_id() === windowId) {
-                    return window;
-                }
-            }
-        } catch (error) {
-            logger.error(
-                `WindowTracker: Error finding window ${windowId}`,
-                error,
-            );
-        }
-        return null;
-    }
-
-    // Public methods for external access
     getTrackedWindows(): number[] {
         return Array.from(this.trackedWindows);
     }
@@ -260,21 +152,11 @@ export class WindowTracker {
         return this.trackedWindows.size;
     }
 
-    /**
-     * Centers a window on the current monitor
-     */
     private centerWindow(window: Meta.Window): void {
-        if (this.isDestroying || !this.isWindowValid(window)) {
-            logger.debug(
-                "WindowTracker: Skipping center window - window invalid or destroying",
-            );
-            return;
-        }
+        if (this.isDestroying) return;
 
         try {
             const { x, y } = this.getCenterPosition(window);
-
-            // Move the window to center position
             window.move_frame(true, x, y);
 
             logger.debug(
@@ -287,9 +169,6 @@ export class WindowTracker {
         }
     }
 
-    /**
-     * Gets the center position of a window
-     */
     private getCenterPosition(window: Meta.Window): { x: number; y: number } {
         const monitor = window.get_monitor();
         const display = global.display;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ export default class Vicinae extends Extension {
     private settings!: Gio.Settings | null;
     private settingsConnection!: number;
     private launcherSettingsConnection!: number;
+    private blockedAppsConnection!: number;
 
     async enable() {
         logger.info("Vicinae extension enabled");
@@ -71,14 +72,17 @@ export default class Vicinae extends Extension {
             },
         );
 
-        this.settings.connect("changed::blocked-applications", () => {
-            if (this.clipboardManager && this.settings) {
-                this.clipboardManager.updateSettings(this.settings);
-                logger.debug(
-                    "Updated clipboard manager with new blocked applications list",
-                );
-            }
-        });
+        this.blockedAppsConnection = this.settings.connect(
+            "changed::blocked-applications",
+            () => {
+                if (this.clipboardManager && this.settings) {
+                    this.clipboardManager.updateSettings(this.settings);
+                    logger.debug(
+                        "Updated clipboard manager with new blocked applications list",
+                    );
+                }
+            },
+        );
 
         logger.info("Vicinae extension initialized successfully");
     }
@@ -169,6 +173,11 @@ export default class Vicinae extends Extension {
         if (this.launcherSettingsConnection) {
             this.settings?.disconnect(this.launcherSettingsConnection);
             this.launcherSettingsConnection = 0;
+        }
+
+        if (this.blockedAppsConnection) {
+            this.settings?.disconnect(this.blockedAppsConnection);
+            this.blockedAppsConnection = 0;
         }
 
         if (this.launcherManager) {


### PR DESCRIPTION
The extension connects directly to Meta.Window's destroy and unmanaged signals with closures that capture the window reference. When the GC collects these windows, the destroy signal fires during the sweep phase, calling back into JS and segfaulting gnome-shell:

```
gnome-shell: Attempting to call back into JSAPI during the sweeping phase of GC.
gnome-shell: GNOME Shell crashed with signal 11
kernel: gnome-shell[5901]: segfault at 10 ip ... in libmozjs-140.so
```

This crashes the entire Wayland session and logs the user out. It happens more frequently when windows are created/destroyed rapidly (launching Electron apps, switching displays, etc).

This is a known anti-pattern in GNOME Shell extensions as you can't safely connect to `destroy` on `Meta.Window` because the signal can fire during GC. The fix is to use `global.window_manager.connect("destroy", ...)` instead, which fires at the compositor level before GC is involved.

Changes:

- `window-tracker.ts`: Replace per-window `destroy`/`unmanaged` signal connections with a single `global.window_manager` destroy handler. Remove all the validator/cleanup machinery that was trying to work around the underlying issue.
- `windows-service.ts`: Same destroy signal fix. Also fix the `size-changed` callback to not hold a strong reference to `Meta.Window` (same class of bug). Track the `GLib.idle_add` source ID from the focus handler so it gets cleaned up on disable.
- `extension.ts`: The `changed::blocked-applications` signal connection was never saved, so it leaked on disable. Save and disconnect it.

Most of the removed code was defensive workarounds for the signal life cycle problem that no longer exists.

Tested on Ubuntu 25.10, GNOME Shell 49, kernel 6.17, AMD RX 9070 on Wayland, but please test it before merging, as I may not know all of the edge cases.