### PR TITLE
fix: validate monitor index before centering window to prevent SIGSEGV

### DIFF
--- a/src/core/launcher/window-tracker.ts
+++ b/src/core/launcher/window-tracker.ts
@@ -156,7 +156,10 @@ export class WindowTracker {
         if (this.isDestroying) return;
 
         try {
-            const { x, y } = this.getCenterPosition(window);
+            const pos = this.getCenterPosition(window);
+            if (!pos) return;
+
+            const { x, y } = pos;
             window.move_frame(true, x, y);
 
             logger.debug(
@@ -169,9 +172,18 @@ export class WindowTracker {
         }
     }
 
-    private getCenterPosition(window: Meta.Window): { x: number; y: number } {
+    private getCenterPosition(window: Meta.Window): { x: number; y: number } | null {
         const monitor = window.get_monitor();
         const display = global.display;
+        const nMonitors = display.get_n_monitors();
+
+        if (monitor < 0 || monitor >= nMonitors) {
+            logger.debug(
+                `WindowTracker: Invalid monitor index ${monitor} (n_monitors=${nMonitors}), skipping center`,
+            );
+            return null;
+        }
+
         const monitorGeometry = display.get_monitor_geometry(monitor);
 
         const frame = window.get_frame_rect();


### PR DESCRIPTION
## Summary

`getCenterPosition()` in `WindowTracker` calls `display.get_monitor_geometry(monitor)` using the index from `window.get_monitor()` without validating it first. When a window is newly created (via the `window-created` signal handled through `GLib.idle_add`), the monitor index can be `-1` or stale (e.g. if a monitor was disconnected), which causes Mutter to crash with a **SIGSEGV** in `meta_window_update_monitor` → `meta_window_move_resize_internal`.

### Crash details

- **Signal:** SIGSEGV (Segmentation Fault)
- **Environment:** GNOME Shell 49.4, Fedora 43, Wayland
- **Coredump stack trace:**
  ```
  #0  meta_window_update_monitor (libmutter-17.so.0)
  #1  meta_window_wayland_update_main_monitor.cold (libmutter-17.so.0)
  #2  meta_window_update_monitor (libmutter-17.so.0)
  #3  meta_window_move_resize_internal (libmutter-17.so.0)
  ...
  #20 g_idle_dispatch (libglib-2.0.so.0)
  ```
- **Last log before crash:**
  ```
  meta_display_get_monitor_geometry: assertion 'monitor >= 0 && monitor < n_logical_monitors' failed
  ```

### Reproduction path

1. `window-created` signal fires
2. `GLib.idle_add` schedules `handleNewWindow`
3. `handleNewWindow` → `centerWindow` → `getCenterPosition`
4. `window.get_monitor()` returns an invalid index (e.g. `-1`)
5. `display.get_monitor_geometry(invalidIndex)` triggers assertion failure
6. `window.move_frame()` → `meta_window_move_resize_internal` → **SIGSEGV**

### Fix

Validate the monitor index against `display.get_n_monitors()` before calling `get_monitor_geometry`. If invalid, `getCenterPosition` returns `null` and `centerWindow` skips the operation gracefully.

## Test plan

- [x] Open/close Vicinae tracked windows with single and multi-monitor setups
- [x] Disconnect a monitor while a tracked window is being created
- [x] Verify no assertion failures or crashes in `journalctl --user`

🤖 Generated with [Claude Code](https://claude.com/claude-code)