### PR TITLE
refactor: move Clipboard settings to dedicated tab.

### DIFF
--- a/src/core/clipboard/clipboard-manager.ts
+++ b/src/core/clipboard/clipboard-manager.ts
@@ -20,22 +20,29 @@ export class VicinaeClipboardManager {
     private selection: Meta.Selection | null = null;
     private signals = new SignalRegistry();
     private settings: Gio.Settings | null = null;
+    private isMonitoring = false;
 
     constructor() {
         this.contentHandlers = createHandlers();
+        this.clipboard = St.Clipboard.get_default();
+        this.selection = Shell.Global.get().get_display().get_selection();
+        
+        if (!this.selection) {
+            logger.error("Failed to get selection instance in clipboard manager");
+        }
     }
 
     enable() {
-        if (!this.clipboard) {
+        if (!this.isMonitoring) {
+            this.isMonitoring = true;
             this.setupClipboardMonitoring();
         }
     }
 
     disable() {
-        if (this.clipboard) {
+        if (this.isMonitoring) {
             this.signals.disconnectAll();
-            this.clipboard = null;
-            this.selection = null;
+            this.isMonitoring = false;
             logger.info("Clipboard monitoring disabled");
         }
     }
@@ -127,9 +134,6 @@ export class VicinaeClipboardManager {
 
     private setupClipboardMonitoring() {
         try {
-            this.clipboard = St.Clipboard.get_default();
-            this.selection = Shell.Global.get().get_display().get_selection();
-
             if (this.selection) {
                 const selectionId = this.selection.connect(
                     "owner-changed",
@@ -144,8 +148,6 @@ export class VicinaeClipboardManager {
                 logger.info(
                     "Clipboard monitoring set up successfully using selection listener",
                 );
-            } else {
-                logger.error("Failed to get selection instance");
             }
         } catch (error) {
             logger.error("Error setting up clipboard monitoring", error);

--- a/src/core/clipboard/clipboard-manager.ts
+++ b/src/core/clipboard/clipboard-manager.ts
@@ -26,9 +26,11 @@ export class VicinaeClipboardManager {
         this.contentHandlers = createHandlers();
         this.clipboard = St.Clipboard.get_default();
         this.selection = Shell.Global.get().get_display().get_selection();
-        
+
         if (!this.selection) {
-            logger.error("Failed to get selection instance in clipboard manager");
+            logger.error(
+                "Failed to get selection instance in clipboard manager",
+            );
         }
     }
 
@@ -180,19 +182,19 @@ export class VicinaeClipboardManager {
                 const context =
                     handler.priority >= 1
                         ? {
-                            storeBinaryData: (
-                                marker: string,
-                                data: unknown,
-                                mimeType: string,
-                            ) => {
-                                this.binaryStore.set(
-                                    marker,
-                                    data as BufferLike,
-                                    mimeType,
-                                );
-                                logger.debug(`Stored binary data: ${marker}`);
-                            },
-                        }
+                              storeBinaryData: (
+                                  marker: string,
+                                  data: unknown,
+                                  mimeType: string,
+                              ) => {
+                                  this.binaryStore.set(
+                                      marker,
+                                      data as BufferLike,
+                                      mimeType,
+                                  );
+                                  logger.debug(`Stored binary data: ${marker}`);
+                              },
+                          }
                         : undefined;
 
                 handler.capture(

--- a/src/core/clipboard/clipboard-manager.ts
+++ b/src/core/clipboard/clipboard-manager.ts
@@ -26,7 +26,18 @@ export class VicinaeClipboardManager {
     }
 
     enable() {
-        this.setupClipboardMonitoring();
+        if (!this.clipboard) {
+            this.setupClipboardMonitoring();
+        }
+    }
+
+    disable() {
+        if (this.clipboard) {
+            this.signals.disconnectAll();
+            this.clipboard = null;
+            this.selection = null;
+            logger.info("Clipboard monitoring disabled");
+        }
     }
 
     setSettings(settings: Gio.Settings): void {
@@ -167,19 +178,19 @@ export class VicinaeClipboardManager {
                 const context =
                     handler.priority >= 1
                         ? {
-                              storeBinaryData: (
-                                  marker: string,
-                                  data: unknown,
-                                  mimeType: string,
-                              ) => {
-                                  this.binaryStore.set(
-                                      marker,
-                                      data as BufferLike,
-                                      mimeType,
-                                  );
-                                  logger.debug(`Stored binary data: ${marker}`);
-                              },
-                          }
+                            storeBinaryData: (
+                                marker: string,
+                                data: unknown,
+                                mimeType: string,
+                            ) => {
+                                this.binaryStore.set(
+                                    marker,
+                                    data as BufferLike,
+                                    mimeType,
+                                );
+                                logger.debug(`Stored binary data: ${marker}`);
+                            },
+                        }
                         : undefined;
 
                 handler.capture(
@@ -382,7 +393,7 @@ export class VicinaeClipboardManager {
     }
 
     destroy(): void {
-        this.signals.disconnectAll();
+        this.disable();
         this.eventListeners = [];
         this.currentContent = "";
         logger.debug(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,9 @@ export default class Vicinae extends Extension {
         initializeLogger(this.settings);
 
         this.clipboardManager = new VicinaeClipboardManager();
-        this.clipboardManager.enable();
+        if (this.settings.get_boolean("enable-clipboard-monitoring")) {
+            this.clipboardManager.enable();
+        }
         this.clipboardManager.setSettings(this.settings);
 
         const appClass =
@@ -92,6 +94,22 @@ export default class Vicinae extends Extension {
             },
         );
         this.signals.add(() => this.settings?.disconnect(blockedAppsId));
+
+        const enableMonitoringId = this.settings.connect(
+            "changed::enable-clipboard-monitoring",
+            () => {
+                if (this.clipboardManager && this.settings) {
+                    if (
+                        this.settings.get_boolean("enable-clipboard-monitoring")
+                    ) {
+                        this.clipboardManager.enable();
+                    } else {
+                        this.clipboardManager.disable();
+                    }
+                }
+            },
+        );
+        this.signals.add(() => this.settings?.disconnect(enableMonitoringId));
 
         logger.info("Vicinae extension initialized successfully");
     }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -4,6 +4,7 @@ import type Gio from "gi://Gio";
 import { ExtensionPreferences } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
 import { AboutPage } from "./prefs/AboutPage.js";
+import { ClipboardPage } from "./prefs/ClipboardPage.js";
 import { GeneralPage } from "./prefs/GeneralPage.js";
 
 export default class VicinaePrefs extends ExtensionPreferences {
@@ -21,6 +22,10 @@ export default class VicinaePrefs extends ExtensionPreferences {
         const generalPage = new GeneralPage();
         generalPage.bindSettings(prefsWindow._settings);
         prefsWindow.add(generalPage);
+
+        const clipboardPage = new ClipboardPage();
+        clipboardPage.bindSettings(prefsWindow._settings);
+        prefsWindow.add(clipboardPage);
 
         const aboutPage = new AboutPage();
         aboutPage.setMetadata(this.metadata);

--- a/src/prefs/ClipboardPage.ts
+++ b/src/prefs/ClipboardPage.ts
@@ -22,8 +22,7 @@ export const ClipboardPage = GObject.registerClass(
     },
     class ClipboardPage extends Adw.PreferencesPage {
         private settings!: Gio.Settings;
-        private blockedAppRows: Map<string, BlockedAppRowInstance> = new Map();
-        private emptyRows: Set<BlockedAppRowInstance> = new Set();
+        private rowInstances: Set<BlockedAppRowInstance> = new Set();
 
         bindSettings(settings: Gio.Settings) {
             this.settings = settings;
@@ -87,12 +86,10 @@ export const ClipboardPage = GObject.registerClass(
                 }
 
                 const children = this as unknown as ClipboardPageChildren;
-                const existingRows = Array.from(this.blockedAppRows.values());
-                existingRows.forEach((row) => {
+                this.rowInstances.forEach((row) => {
                     children._blockedAppsGroup.remove(row);
                 });
-                this.blockedAppRows.clear();
-                this.emptyRows.clear();
+                this.rowInstances.clear();
 
                 uniqueBlockedApps.forEach((windowClass) => {
                     this.addBlockedAppRow(windowClass);
@@ -115,11 +112,11 @@ export const ClipboardPage = GObject.registerClass(
         }
 
         private addEmptyBlockedAppRow() {
-            if (this.emptyRows.size > 0) {
-                const firstEmptyRow = this.emptyRows.values().next().value;
-                if (firstEmptyRow) {
-                    firstEmptyRow.focusInput();
-                }
+            const firstEmptyRow = Array.from(this.rowInstances).find((r) =>
+                r.isEmpty(),
+            );
+            if (firstEmptyRow) {
+                firstEmptyRow.focusInput();
                 return;
             }
             this.addBlockedAppRow("");
@@ -145,36 +142,27 @@ export const ClipboardPage = GObject.registerClass(
 
             children._blockedAppsGroup.add_row(row);
 
-            if (windowClass) {
-                this.blockedAppRows.set(windowClass, row);
-            } else {
-                this.emptyRows.add(row);
+            if (!windowClass) {
                 row.focusInput();
             }
+
+            this.rowInstances.add(row);
 
             this.updateAddButtonState();
         }
 
-        private handleInputChange(row: BlockedAppRowInstance) {
-            const isEmpty = row.isEmpty();
-            const wasEmpty = this.emptyRows.has(row);
-
-            if (isEmpty && !wasEmpty) {
-                this.emptyRows.add(row);
-            } else if (!isEmpty && wasEmpty) {
-                this.emptyRows.delete(row);
-            }
-
+        private handleInputChange(_row: BlockedAppRowInstance) {
             this.updateAddButtonState();
         }
 
         private updateAddButtonState() {
             const children = this as unknown as ClipboardPageChildren;
-            const hasEmptyRows = this.emptyRows.size > 0;
+            const hasEmptyRows = Array.from(this.rowInstances).some((r) =>
+                r.isEmpty(),
+            );
             children._addWindowButton.set_sensitive(!hasEmptyRows);
 
-            const hasAnyRows =
-                this.blockedAppRows.size > 0 || this.emptyRows.size > 0;
+            const hasAnyRows = this.rowInstances.size > 0;
             children._emptyPlaceholderRow.set_visible(!hasAnyRows);
         }
 
@@ -216,7 +204,7 @@ export const ClipboardPage = GObject.registerClass(
         }
 
         private updateBlockedAppInSettings(
-            row: BlockedAppRowInstance,
+            _row: BlockedAppRowInstance,
             oldClass: string,
             newClass: string,
         ) {
@@ -238,11 +226,6 @@ export const ClipboardPage = GObject.registerClass(
                 filteredApps.push(newClass);
 
                 this.settings.set_strv("blocked-applications", filteredApps);
-
-                if (oldClass && oldClass.trim() !== "") {
-                    this.blockedAppRows.delete(oldClass);
-                }
-                this.blockedAppRows.set(newClass, row);
             } catch (error) {
                 logger.error("Error updating blocked app in settings", error);
             }
@@ -266,8 +249,6 @@ export const ClipboardPage = GObject.registerClass(
                 );
 
                 this.settings.set_strv("blocked-applications", filteredApps);
-
-                this.blockedAppRows.delete(oldClass);
             } catch (error) {
                 logger.error("Error removing blocked app from settings", error);
             }
@@ -286,12 +267,9 @@ export const ClipboardPage = GObject.registerClass(
                     (app) => app !== windowClass,
                 );
                 this.settings.set_strv("blocked-applications", updatedApps);
-
-                this.blockedAppRows.delete(windowClass);
-            } else {
-                this.emptyRows.delete(row);
             }
 
+            this.rowInstances.delete(row);
             children._blockedAppsGroup.remove(row);
 
             this.updateAddButtonState();

--- a/src/prefs/ClipboardPage.ts
+++ b/src/prefs/ClipboardPage.ts
@@ -1,0 +1,300 @@
+import Adw from "gi://Adw";
+import Gio from "gi://Gio";
+import GObject from "gi://GObject";
+import type { ClipboardPageChildren } from "../types/prefs.js";
+import { getTemplate } from "../utils/getTemplate.js";
+import { logger } from "../utils/logger.js";
+import {
+    BlockedAppRow,
+    type BlockedAppRowInstance,
+} from "./components/blocked-app-row.js";
+
+export const ClipboardPage = GObject.registerClass(
+    {
+        GTypeName: "VicinaeClipboardPage",
+        Template: getTemplate("ClipboardPage"),
+        InternalChildren: [
+            "enableClipboardMonitoring",
+            "blockedAppsGroup",
+            "emptyPlaceholderRow",
+            "addWindowButton",
+        ],
+    },
+    class ClipboardPage extends Adw.PreferencesPage {
+        private settings!: Gio.Settings;
+        private blockedAppRows: Map<string, BlockedAppRowInstance> = new Map();
+        private emptyRows: Set<BlockedAppRowInstance> = new Set();
+
+        bindSettings(settings: Gio.Settings) {
+            this.settings = settings;
+            logger.debug("Settings bound to ClipboardPage");
+
+            this.loadBlockedApplications();
+            this.updateAddButtonState();
+
+            const children = this as unknown as ClipboardPageChildren;
+
+            this.connectAddBlockedAppButton(children);
+            this.bindEnableClipboardMonitoring(settings, children);
+        }
+
+        /** "Add window class" → append an empty blocked-app row. */
+        private connectAddBlockedAppButton(children: ClipboardPageChildren) {
+            children._addWindowButton.connect("clicked", () => {
+                this.addEmptyBlockedAppRow();
+            });
+        }
+
+        /** `enable-clipboard-monitoring` ↔ clipboard monitoring switch. */
+        private bindEnableClipboardMonitoring(
+            settings: Gio.Settings,
+            children: ClipboardPageChildren,
+        ) {
+            settings.bind(
+                "enable-clipboard-monitoring",
+                children._enableClipboardMonitoring,
+                "active",
+                Gio.SettingsBindFlags.DEFAULT,
+            );
+
+            // Update sensitivity of blocked apps group based on the switch
+            const updateSensitivity = () => {
+                const isEnabled = settings.get_boolean(
+                    "enable-clipboard-monitoring",
+                );
+                children._blockedAppsGroup.set_sensitive(isEnabled);
+            };
+
+            settings.connect(
+                "changed::enable-clipboard-monitoring",
+                updateSensitivity,
+            );
+            updateSensitivity();
+        }
+
+        private loadBlockedApplications() {
+            try {
+                const blockedApps = this.settings.get_strv(
+                    "blocked-applications",
+                );
+
+                const uniqueBlockedApps = this.removeDuplicates(blockedApps);
+                if (uniqueBlockedApps.length !== blockedApps.length) {
+                    this.settings.set_strv(
+                        "blocked-applications",
+                        uniqueBlockedApps,
+                    );
+                }
+
+                const children = this as unknown as ClipboardPageChildren;
+                const existingRows = Array.from(this.blockedAppRows.values());
+                existingRows.forEach((row) => {
+                    children._blockedAppsGroup.remove(row);
+                });
+                this.blockedAppRows.clear();
+                this.emptyRows.clear();
+
+                uniqueBlockedApps.forEach((windowClass) => {
+                    this.addBlockedAppRow(windowClass);
+                });
+            } catch (error) {
+                logger.error("Error loading blocked applications", error);
+            }
+        }
+
+        private removeDuplicates(apps: string[]): string[] {
+            const seen = new Set<string>();
+            return apps.filter((app) => {
+                const lowerApp = app.toLowerCase();
+                if (seen.has(lowerApp)) {
+                    return false;
+                }
+                seen.add(lowerApp);
+                return true;
+            });
+        }
+
+        private addEmptyBlockedAppRow() {
+            if (this.emptyRows.size > 0) {
+                const firstEmptyRow = this.emptyRows.values().next().value;
+                if (firstEmptyRow) {
+                    firstEmptyRow.focusInput();
+                }
+                return;
+            }
+            this.addBlockedAppRow("");
+        }
+
+        private addBlockedAppRow(windowClass: string) {
+            const children = this as unknown as ClipboardPageChildren;
+
+            const row = new BlockedAppRow();
+            row.setWindowClass(windowClass);
+
+            row.connect("delete-requested", () => {
+                this.removeBlockedAppRow(row);
+            });
+
+            row.connect("save-requested", () => {
+                this.handleSaveRequest(row);
+            });
+
+            row.connect("input-changed", () => {
+                this.handleInputChange(row);
+            });
+
+            children._blockedAppsGroup.add_row(row);
+
+            if (windowClass) {
+                this.blockedAppRows.set(windowClass, row);
+            } else {
+                this.emptyRows.add(row);
+                row.focusInput();
+            }
+
+            this.updateAddButtonState();
+        }
+
+        private handleInputChange(row: BlockedAppRowInstance) {
+            const isEmpty = row.isEmpty();
+            const wasEmpty = this.emptyRows.has(row);
+
+            if (isEmpty && !wasEmpty) {
+                this.emptyRows.add(row);
+            } else if (!isEmpty && wasEmpty) {
+                this.emptyRows.delete(row);
+            }
+
+            this.updateAddButtonState();
+        }
+
+        private updateAddButtonState() {
+            const children = this as unknown as ClipboardPageChildren;
+            const hasEmptyRows = this.emptyRows.size > 0;
+            children._addWindowButton.set_sensitive(!hasEmptyRows);
+
+            const hasAnyRows =
+                this.blockedAppRows.size > 0 || this.emptyRows.size > 0;
+            children._emptyPlaceholderRow.set_visible(!hasAnyRows);
+        }
+
+        private handleSaveRequest(row: BlockedAppRowInstance) {
+            const oldClass = row.getOriginalWindowClass();
+            const newClass = row.getInputValue().trim();
+
+            if (newClass) {
+                const currentBlockedApps = this.settings.get_strv(
+                    "blocked-applications",
+                );
+
+                const isDuplicate = currentBlockedApps.some(
+                    (app) =>
+                        app !== oldClass &&
+                        app.toLowerCase() === newClass.toLowerCase(),
+                );
+
+                if (isDuplicate) {
+                    const root = this.get_root() as Adw.PreferencesWindow;
+                    if (root && "add_toast" in root) {
+                        const toast = new Adw.Toast({
+                            title: `Can't add ${newClass} to the list, because it's already there`,
+                        });
+                        (
+                            root as Adw.PreferencesWindow & {
+                                add_toast: (toast: Adw.Toast) => void;
+                            }
+                        ).add_toast(toast);
+                    }
+                    row.setWindowClass(oldClass);
+                    return;
+                }
+                this.updateBlockedAppInSettings(row, oldClass, newClass);
+            } else {
+                this.removeBlockedAppFromSettings(row, oldClass);
+            }
+            this.updateAddButtonState();
+        }
+
+        private updateBlockedAppInSettings(
+            row: BlockedAppRowInstance,
+            oldClass: string,
+            newClass: string,
+        ) {
+            try {
+                const currentBlockedApps = this.settings.get_strv(
+                    "blocked-applications",
+                );
+
+                let filteredApps: string[];
+
+                if (oldClass && oldClass.trim() !== "") {
+                    filteredApps = currentBlockedApps.filter(
+                        (app) => app !== oldClass,
+                    );
+                } else {
+                    filteredApps = [...currentBlockedApps];
+                }
+
+                filteredApps.push(newClass);
+
+                this.settings.set_strv("blocked-applications", filteredApps);
+
+                if (oldClass && oldClass.trim() !== "") {
+                    this.blockedAppRows.delete(oldClass);
+                }
+                this.blockedAppRows.set(newClass, row);
+            } catch (error) {
+                logger.error("Error updating blocked app in settings", error);
+            }
+        }
+
+        private removeBlockedAppFromSettings(
+            _row: BlockedAppRowInstance,
+            oldClass: string,
+        ) {
+            try {
+                if (!oldClass || oldClass.trim() === "") {
+                    return;
+                }
+
+                const currentBlockedApps = this.settings.get_strv(
+                    "blocked-applications",
+                );
+
+                const filteredApps = currentBlockedApps.filter(
+                    (app) => app !== oldClass,
+                );
+
+                this.settings.set_strv("blocked-applications", filteredApps);
+
+                this.blockedAppRows.delete(oldClass);
+            } catch (error) {
+                logger.error("Error removing blocked app from settings", error);
+            }
+        }
+
+        private removeBlockedAppRow(row: BlockedAppRowInstance) {
+            const children = this as unknown as ClipboardPageChildren;
+            const windowClass = row.getWindowClass();
+
+            if (windowClass) {
+                const currentApps = this.settings.get_strv(
+                    "blocked-applications",
+                );
+
+                const updatedApps = currentApps.filter(
+                    (app) => app !== windowClass,
+                );
+                this.settings.set_strv("blocked-applications", updatedApps);
+
+                this.blockedAppRows.delete(windowClass);
+            } else {
+                this.emptyRows.delete(row);
+            }
+
+            children._blockedAppsGroup.remove(row);
+
+            this.updateAddButtonState();
+        }
+    },
+);

--- a/src/prefs/GeneralPage.ts
+++ b/src/prefs/GeneralPage.ts
@@ -4,10 +4,6 @@ import GObject from "gi://GObject";
 import type { GeneralPageChildren } from "../types/prefs.js";
 import { getTemplate } from "../utils/getTemplate.js";
 import { logger } from "../utils/logger.js";
-import {
-    BlockedAppRow,
-    type BlockedAppRowInstance,
-} from "./components/blocked-app-row.js";
 
 /** GSettings `logging-level` string values, in ComboRow order. */
 const LOGGING_LEVELS: readonly string[] = ["error", "warn", "info", "debug"];
@@ -17,8 +13,6 @@ export const GeneralPage = GObject.registerClass(
         GTypeName: "VicinaeGeneralPage",
         Template: getTemplate("GeneralPage"),
         InternalChildren: [
-            "blockedAppsGroup",
-            "addWindowButton",
             "showStatusIndicator",
             "loggingLevel",
             "launcherAutoCloseFocusLoss",
@@ -28,30 +22,17 @@ export const GeneralPage = GObject.registerClass(
     },
     class GeneralPage extends Adw.PreferencesPage {
         private settings!: Gio.Settings;
-        private blockedAppRows: Map<string, BlockedAppRowInstance> = new Map();
-        private emptyRows: Set<BlockedAppRowInstance> = new Set();
 
         bindSettings(settings: Gio.Settings) {
             this.settings = settings;
             logger.debug("Settings bound to GeneralPage");
 
-            this.loadBlockedApplications();
-            this.updateAddButtonState();
-
             const children = this as unknown as GeneralPageChildren;
 
-            this.connectAddBlockedAppButton(children);
             this.bindShowStatusIndicator(settings, children);
             this.bindLoggingLevel(settings, children);
             this.bindLauncherAutoCloseFocusLoss(settings, children);
             this.bindLauncherAppClass(settings, children);
-        }
-
-        /** "Add window class" → append an empty blocked-app row. */
-        private connectAddBlockedAppButton(children: GeneralPageChildren) {
-            children._addWindowButton.connect("clicked", () => {
-                this.addEmptyBlockedAppRow();
-            });
         }
 
         /** `show-status-indicator` ↔ status indicator switch. */
@@ -116,220 +97,6 @@ export const GeneralPage = GObject.registerClass(
                 "text",
                 Gio.SettingsBindFlags.DEFAULT,
             );
-        }
-
-        private loadBlockedApplications() {
-            try {
-                const blockedApps = this.settings.get_strv(
-                    "blocked-applications",
-                );
-
-                const uniqueBlockedApps = this.removeDuplicates(blockedApps);
-                if (uniqueBlockedApps.length !== blockedApps.length) {
-                    this.settings.set_strv(
-                        "blocked-applications",
-                        uniqueBlockedApps,
-                    );
-                }
-
-                const children = this as unknown as GeneralPageChildren;
-                const existingRows = Array.from(this.blockedAppRows.values());
-                existingRows.forEach((row) => {
-                    children._blockedAppsGroup.remove(row);
-                });
-                this.blockedAppRows.clear();
-                this.emptyRows.clear();
-
-                uniqueBlockedApps.forEach((windowClass) => {
-                    this.addBlockedAppRow(windowClass);
-                });
-            } catch (error) {
-                logger.error("Error loading blocked applications", error);
-            }
-        }
-
-        private removeDuplicates(apps: string[]): string[] {
-            const seen = new Set<string>();
-            return apps.filter((app) => {
-                const lowerApp = app.toLowerCase();
-                if (seen.has(lowerApp)) {
-                    return false;
-                }
-                seen.add(lowerApp);
-                return true;
-            });
-        }
-
-        private addEmptyBlockedAppRow() {
-            this.addBlockedAppRow("");
-        }
-
-        private addBlockedAppRow(windowClass: string) {
-            const children = this as unknown as GeneralPageChildren;
-
-            const row = new BlockedAppRow();
-            row.setWindowClass(windowClass);
-
-            row.connect("delete-requested", () => {
-                this.removeBlockedAppRow(row);
-            });
-
-            row.connect("save-requested", () => {
-                this.handleSaveRequest(row);
-            });
-
-            row.connect("input-changed", () => {
-                this.handleInputChange(row);
-            });
-
-            children._blockedAppsGroup.add(row);
-
-            if (windowClass) {
-                this.blockedAppRows.set(windowClass, row);
-            } else {
-                this.emptyRows.add(row);
-                row.updateCheckButtonState();
-            }
-
-            this.updateAddButtonState();
-        }
-
-        private handleInputChange(row: BlockedAppRowInstance) {
-            const isEmpty = row.isEmpty();
-            const wasEmpty = this.emptyRows.has(row);
-
-            if (isEmpty && !wasEmpty) {
-                this.emptyRows.add(row);
-            } else if (!isEmpty && wasEmpty) {
-                this.emptyRows.delete(row);
-            }
-
-            this.updateAddButtonState();
-        }
-
-        private updateAddButtonState() {
-            const children = this as unknown as GeneralPageChildren;
-            const hasEmptyRows = this.emptyRows.size > 0;
-            children._addWindowButton.set_sensitive(!hasEmptyRows);
-        }
-
-        private handleSaveRequest(row: BlockedAppRowInstance) {
-            const oldClass = row.getOriginalWindowClass();
-            const newClass = row.getInputValue().trim();
-
-            if (newClass) {
-                const currentBlockedApps = this.settings.get_strv(
-                    "blocked-applications",
-                );
-
-                const isDuplicate = currentBlockedApps.some(
-                    (app) =>
-                        app !== oldClass &&
-                        app.toLowerCase() === newClass.toLowerCase(),
-                );
-
-                if (isDuplicate) {
-                    const root = this.get_root() as Adw.PreferencesWindow;
-                    if (root && "add_toast" in root) {
-                        const toast = new Adw.Toast({
-                            title: `Can't add ${newClass} to the list, because it's already there`,
-                        });
-                        (
-                            root as Adw.PreferencesWindow & {
-                                add_toast: (toast: Adw.Toast) => void;
-                            }
-                        ).add_toast(toast);
-                    }
-                    row.setWindowClass(oldClass);
-                    return;
-                }
-                this.updateBlockedAppInSettings(row, oldClass, newClass);
-            } else {
-                this.removeBlockedAppFromSettings(row, oldClass);
-            }
-            this.updateAddButtonState();
-        }
-
-        private updateBlockedAppInSettings(
-            row: BlockedAppRowInstance,
-            oldClass: string,
-            newClass: string,
-        ) {
-            try {
-                const currentBlockedApps = this.settings.get_strv(
-                    "blocked-applications",
-                );
-
-                let filteredApps: string[];
-
-                if (oldClass && oldClass.trim() !== "") {
-                    filteredApps = currentBlockedApps.filter(
-                        (app) => app !== oldClass,
-                    );
-                } else {
-                    filteredApps = [...currentBlockedApps];
-                }
-
-                filteredApps.push(newClass);
-
-                this.settings.set_strv("blocked-applications", filteredApps);
-
-                if (oldClass && oldClass.trim() !== "") {
-                    this.blockedAppRows.delete(oldClass);
-                }
-                this.blockedAppRows.set(newClass, row);
-            } catch (error) {
-                logger.error("Error updating blocked app in settings", error);
-            }
-        }
-
-        private removeBlockedAppFromSettings(
-            _row: BlockedAppRowInstance,
-            oldClass: string,
-        ) {
-            try {
-                if (!oldClass || oldClass.trim() === "") {
-                    return;
-                }
-
-                const currentBlockedApps = this.settings.get_strv(
-                    "blocked-applications",
-                );
-
-                const filteredApps = currentBlockedApps.filter(
-                    (app) => app !== oldClass,
-                );
-
-                this.settings.set_strv("blocked-applications", filteredApps);
-
-                this.blockedAppRows.delete(oldClass);
-            } catch (error) {
-                logger.error("Error removing blocked app from settings", error);
-            }
-        }
-
-        private removeBlockedAppRow(row: BlockedAppRowInstance) {
-            const children = this as unknown as GeneralPageChildren;
-            const windowClass = row.getWindowClass();
-
-            if (windowClass) {
-                const currentApps = this.settings.get_strv(
-                    "blocked-applications",
-                );
-
-                const updatedApps = currentApps.filter(
-                    (app) => app !== windowClass,
-                );
-                this.settings.set_strv("blocked-applications", updatedApps);
-
-                this.blockedAppRows.delete(windowClass);
-            } else {
-                this.emptyRows.delete(row);
-            }
-
-            children._blockedAppsGroup.remove(row);
-
-            this.updateAddButtonState();
         }
     },
 );

--- a/src/prefs/components/blocked-app-row.ts
+++ b/src/prefs/components/blocked-app-row.ts
@@ -1,9 +1,10 @@
 import Adw from "gi://Adw";
+import GLib from "gi://GLib";
 import GObject from "gi://GObject";
 import Gtk from "gi://Gtk";
 
 /**
- * Expandable row for editing a blocked-application window class in preferences.
+ * Action row for editing a blocked-application window class in preferences.
  */
 export const BlockedAppRow = GObject.registerClass(
     {
@@ -23,31 +24,17 @@ export const BlockedAppRow = GObject.registerClass(
             "input-changed": {},
         },
     },
-    class BlockedAppRow extends Adw.ExpanderRow {
+    class BlockedAppRow extends Adw.EntryRow {
         private windowClass: string = "";
-        private inputValue: string = "";
         private originalWindowClass: string = "";
-        private windowEntry: Adw.EntryRow;
-        private checkButton: Gtk.Button;
+
         private deleteButton: Gtk.Button;
 
         constructor() {
             super();
 
-            this.set_title("Expand this row to enter window class");
-            this.set_subtitle("");
-
-            this.windowEntry = new Adw.EntryRow({
-                title: "Window Class",
-                text: "",
-            });
-
-            this.checkButton = new Gtk.Button({
-                icon_name: "object-select-symbolic",
-                valign: Gtk.Align.CENTER,
-                tooltip_text: "Save and close",
-                css_classes: ["flat", "suggested-action"],
-            });
+            this.set_title("Window Class");
+            this.set_show_apply_button(true);
 
             this.deleteButton = new Gtk.Button({
                 icon_name: "user-trash-symbolic",
@@ -56,38 +43,32 @@ export const BlockedAppRow = GObject.registerClass(
                 css_classes: ["flat"],
             });
 
-            this.add_suffix(this.checkButton);
             this.add_suffix(this.deleteButton);
-            this.add_row(this.windowEntry);
-
-            this.checkButton.visible = false;
-
-            this.checkButton.connect("clicked", () => {
-                this.saveChanges();
-            });
 
             this.deleteButton.connect("clicked", () => {
                 this.emit("delete-requested");
             });
 
-            this.windowEntry.connect("changed", () => {
-                this.inputValue = this.windowEntry.get_text().trim();
-                this.updateCheckButtonState();
+            this.connect("changed", () => {
                 this.emit("input-changed");
             });
 
-            this.connect("notify::expanded", () => {
-                this.updateButtonVisibility();
+            this.connect("apply", () => {
+                this.saveChanges();
+            });
+        }
+
+        focusInput() {
+            GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+                this.grab_focus();
+                return GLib.SOURCE_REMOVE;
             });
         }
 
         setWindowClass(windowClass: string) {
             this.windowClass = windowClass;
-            this.inputValue = windowClass;
             this.originalWindowClass = windowClass;
-            this.windowEntry.set_text(windowClass);
-            this.updateDisplay();
-            this.updateCheckButtonState();
+            this.set_text(windowClass);
         }
 
         getWindowClass(): string {
@@ -95,11 +76,11 @@ export const BlockedAppRow = GObject.registerClass(
         }
 
         getInputValue(): string {
-            return this.inputValue;
+            return this.get_text().trim();
         }
 
         getCurrentWindowClass(): string {
-            return this.inputValue.trim() || this.windowClass;
+            return this.getInputValue() || this.windowClass;
         }
 
         getOriginalWindowClass(): string {
@@ -107,47 +88,22 @@ export const BlockedAppRow = GObject.registerClass(
         }
 
         isEmpty(): boolean {
-            return this.inputValue.trim() === "";
-        }
-
-        closeExpanded() {
-            this.set_expanded(false);
+            return this.getInputValue() === "";
         }
 
         private saveChanges() {
             const oldValue = this.windowClass;
-            const newValue = this.inputValue.trim();
+            const newValue = this.getInputValue();
 
             if (newValue !== oldValue) {
                 this.originalWindowClass = oldValue;
                 this.windowClass = newValue;
-                this.updateDisplay();
                 this.emit("save-requested");
             }
 
-            this.closeExpanded();
-        }
-
-        private updateButtonVisibility() {
-            this.checkButton.visible = this.get_expanded();
-            if (this.get_expanded()) {
-                this.updateCheckButtonState();
-            }
-        }
-
-        updateCheckButtonState() {
-            this.checkButton.set_sensitive(this.inputValue.trim().length > 0);
-        }
-
-        private updateDisplay() {
-            if (this.windowClass) {
-                this.set_title(this.windowClass);
-                this.set_subtitle(
-                    `Expand this row to edit - ${this.windowClass}`,
-                );
-            } else {
-                this.set_title("Expand this row to enter window class");
-                this.set_subtitle("");
+            const root = this.get_root();
+            if (root) {
+                root.set_focus(null);
             }
         }
     },

--- a/src/schemas/org.gnome.shell.extensions.vicinae.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.vicinae.gschema.xml
@@ -6,6 +6,11 @@
             <summary>Blocked applications</summary>
             <description>List of application names that should be blocked from clipboard access</description>
         </key>
+        <key name="enable-clipboard-monitoring" type="b">
+            <default>true</default>
+            <summary>Enable clipboard monitoring</summary>
+            <description>Whether to monitor clipboard changes. Disabling this saves memory but prevents Vicinae from accessing the clipboard history.</description>
+        </key>
         <key name="show-status-indicator" type="b">
             <default>true</default>
             <summary>Show status bar indicator</summary>

--- a/src/types/prefs.ts
+++ b/src/types/prefs.ts
@@ -2,13 +2,18 @@ import type Adw from "gi://Adw";
 import type Gtk from "gi://Gtk";
 
 export interface GeneralPageChildren {
-    _blockedAppsGroup: Adw.PreferencesGroup;
-    _addWindowButton: Gtk.Button;
     _showStatusIndicator: Adw.SwitchRow;
     _loggingLevel: Adw.ComboRow;
     _launcherAutoCloseFocusLoss: Adw.SwitchRow;
     _launcherAppClass: Adw.EntryRow;
     _journalctlCommand: Adw.EntryRow;
+}
+
+export interface ClipboardPageChildren {
+    _enableClipboardMonitoring: Adw.SwitchRow;
+    _blockedAppsGroup: Adw.ExpanderRow;
+    _emptyPlaceholderRow: Adw.ActionRow;
+    _addWindowButton: Gtk.Button;
 }
 
 export interface AboutPageChildren {

--- a/src/ui/ClipboardPage.ui
+++ b/src/ui/ClipboardPage.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <template class="VicinaeClipboardPage" parent="AdwPreferencesPage">
+    <property name="title" translatable="true">Clipboard</property>
+    <property name="icon_name">edit-copy-symbolic</property>
+    <child>
+      <object class="AdwPreferencesGroup" id="clipboardSettingsGroup">
+        <property name="title" translatable="true">Clipboard Settings</property>
+        <property name="description" translatable="true">Manage clipboard functionality and privacy</property>
+        <child>
+          <object class="AdwSwitchRow" id="enableClipboardMonitoring">
+            <property name="title" translatable="true">Enable Clipboard Monitoring</property>
+            <property name="subtitle" translatable="true">Required for Vicinae clipboard history. Disabling saves memory but prevents clipboard functionalities on Vicinae.</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwExpanderRow" id="blockedAppsGroup">
+            <property name="title" translatable="true">Blocked Applications</property>
+            <property name="subtitle" translatable="true">Applications in this list will be blocked from clipboard access</property>
+            <property name="expanded">true</property>
+            <child type="action">
+              <object class="GtkButton" id="addWindowButton">
+                <property name="label" translatable="true">Add window</property>
+                <property name="css-classes">suggested-action</property>
+                <property name="valign">center</property>
+              </object>
+            </child>
+            <child type="action">
+              <object class="GtkMenuButton" id="helpWindowButton">
+                <property name="icon-name">dialog-information-symbolic</property>
+                <property name="valign">center</property>
+                <property name="css-classes">flat</property>
+                <property name="popover">
+                  <object class="GtkPopover">
+                    <child>
+                      <object class="GtkBox">
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
+                        <property name="margin-top">12</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="margin-start">12</property>
+                        <property name="margin-end">12</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label" translatable="true">&lt;b&gt;What is a Window Class?&lt;/b&gt;</property>
+                            <property name="use-markup">true</property>
+                            <property name="halign">start</property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="label" translatable="true">A window class is a unique identifier for an application.
+
+&lt;b&gt;On Wayland:&lt;/b&gt; Press Alt+F2, type &lt;tt&gt;lg&lt;/tt&gt; and press Enter. Go to the "Windows" tab and look for the "wmclass" of your app.
+&lt;b&gt;On X11:&lt;/b&gt; Open a terminal and run &lt;tt&gt;xprop WM_CLASS&lt;/tt&gt;, then click on the application window.</property>
+                            <property name="use-markup">true</property>
+                            <property name="wrap">true</property>
+                            <property name="max-width-chars">40</property>
+                            <property name="halign">start</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow" id="emptyPlaceholderRow">
+                <property name="title" translatable="true">No windows blocked</property>
+                <property name="sensitive">false</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/ui/GeneralPage.ui
+++ b/src/ui/GeneralPage.ui
@@ -5,19 +5,6 @@
     <property name="title" translatable="true">General</property>
     <property name="icon_name">preferences-system-symbolic</property>
     <child>
-      <object class="AdwPreferencesGroup" id="blockedAppsGroup">
-        <property name="title" translatable="true">Blocked Applications</property>
-        <property name="description" translatable="true">Applications in this list will be blocked from clipboard access</property>
-        <property name="header-suffix">
-          <object class="GtkButton" id="addWindowButton">
-            <property name="label" translatable="true">Add window</property>
-            <property name="css-classes">suggested-action</property>
-            <property name="valign">center</property>
-          </object>
-        </property>
-      </object>
-    </child>
-    <child>
       <object class="AdwPreferencesGroup">
         <property name="title" translatable="true">Interface Settings</property>
         <child>


### PR DESCRIPTION
# Description

This PR makes the clipboard features a bit nicer to use and adds more privacy control.

Key updates:

A UI refresh for the settings page to make it easier to navigate.

A new toggle to completely disable clipboard monitoring.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/acff832f-bf75-4397-9481-066f402bce0a" />

## Changes Included

### 1. Toggle to Disable Clipboard Monitoring
Added a new setting to completely disable clipboard monitoring.
* **Privacy-focused**: Ideal for privacy-conscious users who prefer not to have their clipboard observed.
* **Performance**: Disabling the monitoring helps reduce memory pressure and overall overhead on the GNOME Shell environment.

<img width="1074" height="132" alt="image" src="https://github.com/user-attachments/assets/7d7d1ff6-331b-4570-b4ba-635907af7a47" />


### 2. Dedicated Clipboard Settings Tab
* **Moved from General to its own tab**: Previously, if a user had a large list of blocked applications, it would push all other "General" settings completely out of frame, giving the false impression that there were no other settings available without scrolling. 
* Moving this section to a dedicated "Clipboard" tab provides it with the necessary space and ensures it doesn't crowd out other configurations.

| Before | After |
| :---: | :---: |
| <img width="400" alt="Before" src="https://github.com/user-attachments/assets/b843f3d3-f31c-48ac-ba8c-0ed2f3f106f6" /> | <img width="400" alt="After" src="https://github.com/user-attachments/assets/4814e564-3d03-4393-a8f8-08d5772ed141" /> |

### 3. Restructured Settings Hierarchy
* The "Blocked Applications" setting is now properly nested as a child under the "Clipboard settings" group.
* Previously, it was a bespoke setting group in the "General" tab. This structural change (`Clipboard settings -> Blocked Applications`) makes it immediately clear what the blocklist pertains to.

### 4. Refactored Blocked Applications List
* **Improved Readability**: In the old design, each blocked application row took up two lines, requiring the user to click to expand and reveal the window class that uniquely identified the row. This made the list cumbersome to scan.
* **Simplified Layout**: Now, each row directly and concisely represents a unique, easily identifiable window class, making the entire list readable at a glance.

### 5. Added Helper for "Window Class"
* Added a help button/tooltip explaining what a "Window class" is, including brief guidance on how a user might go about finding the window class of an application.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/131703f0-b8bf-4c76-90ed-25151f4f4390" />

### Note on Clipboard Monitoring Behavior:
When a user toggles the `enable-clipboard-monitoring` setting off, the extension immediately disconnects the event listener, meaning no new clipboard history will be collected from that point onward. However, the core clipboard reference is intentionally preserved under the hood. This ensures that the user can still open the Vicinae launcher and successfully paste any existing items that were captured *before* monitoring was paused.

