### PR TITLE
fix(wayland): remove win.delete to prevent protocol crash and ignore …

### DIFF
--- a/src/core/launcher/launcher-manager.ts
+++ b/src/core/launcher/launcher-manager.ts
@@ -117,7 +117,6 @@ export class LauncherManager {
         windowsToClose.forEach((windowId) => {
             try {
                 if (this.isValidWindowId(windowId)) {
-                    this.windowManager.close(windowId);
                     this.config.onWindowClosed?.(windowId);
                     logger.debug(
                         `LauncherManager: Successfully closed window ${windowId}`,


### PR DESCRIPTION
…settings window

Fixes vicinaehq/vicinae#1822

This PR fixes the GNOME extension side of the Wayland crash.

**Changes:**

Removes this.windowManager.close() in launcher-manager.ts. On Wayland, calling win.delete() without a valid event serial causes a Broken pipe crash. The extension now uses only the D-Bus signal to close windows.
Adds a can_minimize() check to isTargetWindow in window-utils.ts. This stops the extension from tracking the Settings window, which supports minimization.
I opened a separate PR in the main Vicinae repository to fix the C++ client. Both PRs are needed to resolve the crash.